### PR TITLE
Add new dropdown for Projects

### DIFF
--- a/__test__/ExperimentTable.test.js
+++ b/__test__/ExperimentTable.test.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
-import { getRandomInt, TableCellDiv, data, tableHeader } from './TestUtils'
+import {shallow, mount} from 'enzyme'
+import {getRandomInt, TableCellDiv, data, tableHeader} from './TestUtils'
 import ExperimentTable from '../src/ExperimentTable'
 import TableFooter from '../src/TableFooter'
 import TableContent from '../src/TableContent'
 import TableSearchHeader from '../src/TableSearchHeader'
-import { Table } from 'evergreen-ui'
+import {Table} from 'evergreen-ui'
 import _ from 'lodash'
 
 describe(`ExperimentTable`, () => {
@@ -29,8 +29,8 @@ describe(`ExperimentTable`, () => {
 
 
   test(`should sort table content and change header text icon`, () => {
-    const randomColumnIndex =  getRandomInt(1, tableHeader.length)
-    props.tableHeader[randomColumnIndex].type=`sort`
+    const randomColumnIndex = getRandomInt(1, tableHeader.length)
+    props.tableHeader[randomColumnIndex].type = `sort`
     const wrapper = mount(<ExperimentTable {...props}/>)
 
     expect(wrapper).toContainExactlyOneMatchingElement(`.icon.icon-common.icon-sort-down`)
@@ -48,17 +48,27 @@ describe(`ExperimentTable`, () => {
   test(`should filter based on kingdom selection`, () => {
     const event = {target: {name: `pollName`, value: `animals`}}
     const wrapper = mount(<ExperimentTable {...props}/>)
-    const kingdomSelect = wrapper.find(`select`).first().at(0)
+    const kingdomSelect = wrapper.find(`select`).at(1)
     kingdomSelect.simulate(`change`, event)
 
     expect(wrapper.state(`selectedKingdom`)).toEqual(`animals`)
     expect(wrapper.find(Table.Row).length).toBeLessThanOrEqual(data.length)
   })
 
+  test(`should filter based on project selection`, () => {
+    const event = {target: {name: `pollName`, value: `HCA`}}
+    const wrapper = mount(<ExperimentTable {...props}/>)
+    const projectSelect = wrapper.find(`select`).first().at(0)
+    projectSelect.simulate(`change`, event)
+
+    expect(wrapper.state(`selectedProject`)).toEqual(`HCA`)
+    expect(wrapper.find(Table.Row).length).toBeLessThanOrEqual(data.length)
+  })
+
   test(`should filter based on numbers of entries per page selection`, () => {
     const event = {target: {name: `pollName`, value: 1}}
     const wrapper = mount(<ExperimentTable {...props}/>)
-    const entriesSelect = wrapper.find(`select`).at(1)
+    const entriesSelect = wrapper.find(`select`).at(2)
     entriesSelect.simulate(`change`, event)
 
     expect(wrapper.state(`entriesPerPage`)).toEqual(1)
@@ -79,7 +89,7 @@ describe(`ExperimentTable`, () => {
   test(`should filter based on table header search`, () => {
     const randomValue = `si`
     const randomColumn = getRandomInt(1, tableHeader.length)
-    props.tableHeader[randomColumn].type=`search`
+    props.tableHeader[randomColumn].type = `search`
 
     const wrapper = mount(<ExperimentTable {...props}/>)
     expect(wrapper.find(`.searchheader${randomColumn}`)).toExist()

--- a/__test__/ExperimentTable.test.js
+++ b/__test__/ExperimentTable.test.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import {shallow, mount} from 'enzyme'
-import {getRandomInt, TableCellDiv, data, tableHeader} from './TestUtils'
+import { shallow, mount } from 'enzyme'
+import { getRandomInt, TableCellDiv, data, tableHeader } from './TestUtils'
 import ExperimentTable from '../src/ExperimentTable'
 import TableFooter from '../src/TableFooter'
 import TableContent from '../src/TableContent'
 import TableSearchHeader from '../src/TableSearchHeader'
-import {Table} from 'evergreen-ui'
+import { Table } from 'evergreen-ui'
 import _ from 'lodash'
 
 describe(`ExperimentTable`, () => {

--- a/__test__/TableSearchHeader.test.js
+++ b/__test__/TableSearchHeader.test.js
@@ -6,6 +6,7 @@ import TableSearchHeader from '../src/TableSearchHeader'
 describe(`TableSearchHeader`, () => {
   const props = {
     kingdomOptions: [`hello`, `bonjour`],
+    projectOptions: [`hello`, `salam`],
     entriesPerPageOptions: [1, 4, 5, 100],
     aaData: data,
     searchAllOnChange: () => {},
@@ -15,9 +16,9 @@ describe(`TableSearchHeader`, () => {
     onChange: (value, column)=>{console.log(value, column)}
   }
 
-  test(`should render two dropdown menues and a search box`, () => {
+  test(`should render three dropdown menues and a search box`, () => {
     const wrapper = shallow(<TableSearchHeader {...props}/>)
-    expect(wrapper.find(`select`)).toHaveLength(2)
+    expect(wrapper.find(`select`)).toHaveLength(3)
     expect(wrapper.find(`input`)).toHaveLength(1)
   })
 

--- a/__test__/TestUtils.js
+++ b/__test__/TestUtils.js
@@ -32,6 +32,7 @@ const data = [
     species: `Mus musculus`,
     kingdom: `animals`,
     experimentalFactors: [`single cell identifier`, `sampling site`,`time`],
+    experimentProjects: [`HCA`]
   },
   {
     experimentType: `DOUBLE`,
@@ -42,7 +43,8 @@ const data = [
     numberOfContrasts: 0,
     species: `Mus musculus`,
     kingdom: `animals`,
-    experimentalFactors: [`single cell identifier`]
+    experimentalFactors: [`single cell identifier`],
+    experimentProjects:[]
   },
   {
     experimentType: `SINGLE`,
@@ -54,6 +56,7 @@ const data = [
     species: `Homo sapiens`,
     kingdom: `plants`,
     experimentalFactors: [`single cell identifier`, `disease`],
+    experimentProjects: [`HCA`, `CZ-Biohub`]
   }
 ]
 

--- a/html/index-bulk.html
+++ b/html/index-bulk.html
@@ -112,7 +112,7 @@
             "developmental stage"
           ],
           "experimentProjects": [
-            "HCA"
+            "Human Cell Atlas"
           ],
           "arrayDesigns": [],
           "arrayDesignNames": []
@@ -130,7 +130,7 @@
             "growth condition"
           ],
           "experimentProjects": [
-            "HCA"
+            "Human Cell Atlas"
           ],
           "arrayDesigns": [
             "A-AGIL-28"
@@ -195,8 +195,8 @@
             "irradiate"
           ],
           "experimentProjects": [
-            "HCA",
-            "CZ-Biohub"
+            "Human Cell Atlas",
+            "Chan-Zuckerberg Biohub"
           ],
           "arrayDesigns": [
             "A-AFFY-45"
@@ -252,7 +252,7 @@
             "organism part"
           ],
           "experimentProjects": [
-            "HCA"
+            "Human Cell Atlas"
           ],
           "arrayDesigns": [],
           "arrayDesignNames": []

--- a/html/index-bulk.html
+++ b/html/index-bulk.html
@@ -3,15 +3,20 @@
 <head>
     <title>Demo</title>
 
-    <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/libraries/foundation-6/css/foundation.css" type="text/css" media="all" />
-    <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/css/ebi-global.css" type="text/css" media="all" />
-    <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
-    <link rel="stylesheet" href="https://www.ebi.ac.uk/gxa/sc/resources/css/theme-atlas.css" type="text/css" media="all">
+    <link rel="stylesheet"
+          href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/libraries/foundation-6/css/foundation.css"
+          type="text/css" media="all"/>
+    <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/css/ebi-global.css"
+          type="text/css" media="all"/>
+    <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css"
+          type="text/css" media="all"/>
+    <link rel="stylesheet" href="https://www.ebi.ac.uk/gxa/sc/resources/css/theme-atlas.css" type="text/css"
+          media="all">
 </head>
 
 <body>
 <div id="wrapper" class="row expanded">
-    <div id="content" class="small-12 columns" >
+    <div id="content" class="small-12 columns">
         <div id="target">
         </div>
     </div>
@@ -23,11 +28,11 @@
 <!-- Set to http://localhost:8080/gxa/ or http://localhost:8080/gxa_sc/ -- Remember the trailing slash! -->
 <script>
   experimentTable.render({
-    host: 'http://www.ebi.ac.uk/',
-    resource: 'gxa/json/experiments',
-    //link to `${host}/${header.resource}/${data[header.link]}/${header.endpoint}`
+      host: 'http://localhost:8080/',
+      resource: 'gxa/json/experiments',
+      //link to `${host}/${header.resource}/${data[header.link]}/${header.endpoint}`
       species: ``,
-     downloadTooltip: `<ul>
+      downloadTooltip: `<ul>
           <li>Raw filtered count matrix after quantification</li>
           <li>Normalised filtered count matrix after quantification</li>
           <li>TPM (transcripts per million RNA molecules - only available for SmartSeq)</li>
@@ -35,512 +40,488 @@
         </ul>`,
       tableHeader:
         [
-            //{title: `index`, width: 60, dataParam: null, link: null},
-            {type: `sort`, title: `Type`, width: 50, dataParam: `experimentType`,
-                image: {
-                        MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL: {
-                            src: "http://localhost:8080/gxa/resources/images/experiments-table/differential.png",
-                            alt: "Microarray 1-colour miRNA"
-                        },
-                        PROTEOMICS_BASELINE: {
-                            src: "http://localhost:8080/gxa/resources/images/experiments-table/baseline.png",
-                            alt: "Proteomics baseline"
-                        },
-                        RNASEQ_MRNA_BASELINE: {
-                            src: "http://localhost:8080/gxa/resources/images/experiments-table/baseline.png",
-                            alt: "RNA-Seq mRNA baseline"
-                        },
-                        MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL: {
-                            src: "http://localhost:8080/gxa/resources/images/experiments-table/differential.png",
-                            alt: "Microarray 2-colour mRNA"
-                        },
-                        MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL: {
-                            src: "http://localhost:8080/gxa/resources/images/experiments-table/differential.png",
-                            alt: "Microarray 1-colour mRNA"
-                        },
-                        RNASEQ_MRNA_DIFFERENTIAL: {
-                            src: "http://localhost:8080/gxa/resources/images/experiments-table/differential.png",
-                            alt: "RNA-Seq mRNA differential"
-                        }
-                }
-            },
+          //{title: `index`, width: 60, dataParam: null, link: null},
+          {
+            type: `sort`, title: `Type`, width: 50, dataParam: `experimentType`,
+            image: {
+              MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL: {
+                src: "http://localhost:8080/gxa/resources/images/experiments-table/differential.png",
+                alt: "Microarray 1-colour miRNA"
+              },
+              PROTEOMICS_BASELINE: {
+                src: "http://localhost:8080/gxa/resources/images/experiments-table/baseline.png",
+                alt: "Proteomics baseline"
+              },
+              RNASEQ_MRNA_BASELINE: {
+                src: "http://localhost:8080/gxa/resources/images/experiments-table/baseline.png",
+                alt: "RNA-Seq mRNA baseline"
+              },
+              MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL: {
+                src: "http://localhost:8080/gxa/resources/images/experiments-table/differential.png",
+                alt: "Microarray 2-colour mRNA"
+              },
+              MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL: {
+                src: "http://localhost:8080/gxa/resources/images/experiments-table/differential.png",
+                alt: "Microarray 1-colour mRNA"
+              },
+              RNASEQ_MRNA_DIFFERENTIAL: {
+                src: "http://localhost:8080/gxa/resources/images/experiments-table/differential.png",
+                alt: "RNA-Seq mRNA differential"
+              }
+            }
+          },
           {type: `sort`, title: `Loaded date`, width: 120, dataParam: `lastUpdate`},
           {type: `search`, title: `species`, width: 200, dataParam: `species`},
-          {type: `search`, title: `experiment description`, width: 400, dataParam: `experimentDescription`,
-            link: `experimentAccession`, resource: `experiments`, endpoint: `Results`},
-          {type: `sort`, title: `Number of assays`, width: 120, dataParam: `numberOfAssays`,
-            link: `experimentAccession`, resource: `experiments`, endpoint: `Experiment%20Design`},
-            {type: `sort`, title: `Comparisons`, width: 100, dataParam: `numberOfContrasts`,
-                link: `experimentAccession`, resource: `experiments`, endpoint: `Experiment%20Design`},
-            {type: `search`, title: `experiment factors`, width: 200, dataParam: `experimentalFactors`},
-            {type: `search`, title: `array designs`, width: 220, dataParam: `arrayDesignNames`,
-                link: `arrayDesigns`, resource: `arrayexpress/arrays`, endpoint: ``}
-            //{type: ``, title: `ArrayExpress`, width: 100, dataParam: `numberOfContrasts`,
-            //   image: `<span class="icon icon-generic" data-icon="L" title="View in Array Express"></span>`,
-            //   link: `experimentAccession`, resource: `arrayexpress/experiments`, endpoint: ``},
-            //{ title: `Download`, width: null,  dataParam: null}
+          {
+            type: `search`, title: `experiment description`, width: 400, dataParam: `experimentDescription`,
+            link: `experimentAccession`, resource: `experiments`, endpoint: `Results`
+          },
+          {
+            type: `sort`, title: `Number of assays`, width: 120, dataParam: `numberOfAssays`,
+            link: `experimentAccession`, resource: `experiments`, endpoint: `Experiment%20Design`
+          },
+          {
+            type: `sort`, title: `Comparisons`, width: 100, dataParam: `numberOfContrasts`,
+            link: `experimentAccession`, resource: `experiments`, endpoint: `Experiment%20Design`
+          },
+          {type: `search`, title: `experiment factors`, width: 200, dataParam: `experimentalFactors`},
+          {
+            type: `search`, title: `array designs`, width: 220, dataParam: `arrayDesignNames`,
+            link: `arrayDesigns`, resource: `arrayexpress/arrays`, endpoint: ``
+          }
+          //{type: ``, title: `ArrayExpress`, width: 100, dataParam: `numberOfContrasts`,
+          //   image: `<span class="icon icon-generic" data-icon="L" title="View in Array Express"></span>`,
+          //   link: `experimentAccession`, resource: `arrayexpress/experiments`, endpoint: ``},
+          //{ title: `Download`, width: null,  dataParam: null}
         ],
-    noResultsMessageFormatter: function(data) { return 'Your search yielded no results: ' + data.reason },
-    enableDownload: false,
-    aaData:[
-      {
-          "experimentType":"RNASEQ_MRNA_BASELINE",
-          "experimentAccession":"E-ERAD-475",
-          "experimentDescription":"Baseline expression from transcriptional profiling of zebrafish developmental stages",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":360,
-          "numberOfContrasts":0,
-          "species":"Danio rerio",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "developmental stage"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
+      noResultsMessageFormatter: function (data) {
+        return 'Your search yielded no results: ' + data.reason
       },
-      {
-          "experimentType":"MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-GEOD-43049",
-          "experimentDescription":"Caco-2 cells: cultured in conventional vs apical anaerobic conditions",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":12,
-          "numberOfContrasts":1,
-          "species":"Homo sapiens",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "growth condition"
+      enableDownload: false,
+      aaData: [
+        {
+          "experimentType": "RNASEQ_MRNA_BASELINE",
+          "experimentAccession": "E-ERAD-475",
+          "experimentDescription": "Baseline expression from transcriptional profiling of zebrafish developmental stages",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 360,
+          "numberOfContrasts": 0,
+          "species": "Danio rerio",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "developmental stage"
           ],
-          "arrayDesigns":[
-              "A-AGIL-28"
+          "experimentProjects": [
+            "HCA"
           ],
-          "arrayDesignNames":[
-              "Agilent Whole Human Genome Microarray 4x44K 014850 G4112F (85 cols x 532 rows)"
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-GEOD-43049",
+          "experimentDescription": "Caco-2 cells: cultured in conventional vs apical anaerobic conditions",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 12,
+          "numberOfContrasts": 1,
+          "species": "Homo sapiens",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "growth condition"
+          ],
+          "experimentProjects": [
+            "HCA"
+          ],
+          "arrayDesigns": [
+            "A-AGIL-28"
+          ],
+          "arrayDesignNames": [
+            "Agilent Whole Human Genome Microarray 4x44K 014850 G4112F (85 cols x 532 rows)"
           ]
-      },
-      {
-          "experimentType":"MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MAXD-6",
-          "experimentDescription":"Transcription profiling by array of Drosophila larvae after parasitoid attack",
-          "lastUpdate":"04-10-2018",
-          "numberOfAssays":89,
-          "numberOfContrasts":9,
-          "species":"Drosophila melanogaster",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "infect",
-              "time"
+        },
+        {
+          "experimentType": "MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MAXD-6",
+          "experimentDescription": "Transcription profiling by array of Drosophila larvae after parasitoid attack",
+          "lastUpdate": "04-10-2018",
+          "numberOfAssays": 89,
+          "numberOfContrasts": 9,
+          "species": "Drosophila melanogaster",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "infect",
+            "time"
           ],
-          "arrayDesigns":[
-              "A-AFFY-17"
+          "experimentProjects": [],
+          "arrayDesigns": [
+            "A-AFFY-17"
           ],
-          "arrayDesignNames":[
-              "Affymetrix GeneChip Drosophila Genome [DrosGenome1]"
+          "arrayDesignNames": [
+            "Affymetrix GeneChip Drosophila Genome [DrosGenome1]"
           ]
-      },
-      {
-          "experimentType":"MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MEXP-1810",
-          "experimentDescription":"Transcription profiling by array of C. elegans isolates treated with dauer larva-inducing pheromone",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":12,
-          "numberOfContrasts":2,
-          "species":"Caenorhabditis elegans",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "compound",
-              "strain"
+        },
+        {
+          "experimentType": "MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MEXP-1810",
+          "experimentDescription": "Transcription profiling by array of C. elegans isolates treated with dauer larva-inducing pheromone",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 12,
+          "numberOfContrasts": 2,
+          "species": "Caenorhabditis elegans",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "compound",
+            "strain"
           ],
-          "arrayDesigns":[
-              "A-AFFY-60"
+          "experimentProjects": [],
+          "arrayDesigns": [
+            "A-AFFY-60"
           ],
-          "arrayDesignNames":[
-              "Affymetrix GeneChip C. elegans Genome Array [Celegans]"
+          "arrayDesignNames": [
+            "Affymetrix GeneChip C. elegans Genome Array [Celegans]"
           ]
-      },
-      {
-          "experimentType":"MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MEXP-1968",
-          "experimentDescription":"Transcription profiling by array of mouse wild type and DNA-repair-deficient primary dermal fibroblasts after treatment with ultraviolet radiation",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":36,
-          "numberOfContrasts":5,
-          "species":"Mus musculus",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "genotype",
-              "irradiate"
+        },
+        {
+          "experimentType": "MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MEXP-1968",
+          "experimentDescription": "Transcription profiling by array of mouse wild type and DNA-repair-deficient primary dermal fibroblasts after treatment with ultraviolet radiation",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 36,
+          "numberOfContrasts": 5,
+          "species": "Mus musculus",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "genotype",
+            "irradiate"
           ],
-          "arrayDesigns":[
-              "A-AFFY-45"
+          "experimentProjects": [
+            "HCA",
+            "CZ-Biohub"
           ],
-          "arrayDesignNames":[
-              "Affymetrix GeneChip Mouse Genome 430 2.0 [Mouse430_2]"
+          "arrayDesigns": [
+            "A-AFFY-45"
+          ],
+          "arrayDesignNames": [
+            "Affymetrix GeneChip Mouse Genome 430 2.0 [Mouse430_2]"
           ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MTAB-1913",
-          "experimentDescription":"Salt stress in salt sensitive Oryza sativa Indica group IR29 ",
-          "lastUpdate":"04-10-2018",
-          "numberOfAssays":30,
-          "numberOfContrasts":15,
-          "species":"Oryza sativa Indica group",
-          "kingdom":"plants",
-          "experimentalFactors":[
-              "growth condition",
-              "time"
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MTAB-1913",
+          "experimentDescription": "Salt stress in salt sensitive Oryza sativa Indica group IR29 ",
+          "lastUpdate": "04-10-2018",
+          "numberOfAssays": 30,
+          "numberOfContrasts": 15,
+          "species": "Oryza sativa Indica group",
+          "kingdom": "plants",
+          "experimentalFactors": [
+            "growth condition",
+            "time"
           ],
-          "arrayDesigns":[
-
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_BASELINE",
+          "experimentAccession": "E-MTAB-2770",
+          "experimentDescription": "RNA-seq of 934 human cancer cell lines from the Cancer Cell Line Encyclopedia",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 934,
+          "numberOfContrasts": 0,
+          "species": "Homo sapiens",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "cell line",
+            "disease"
           ],
-          "arrayDesignNames":[
-
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_BASELINE",
+          "experimentAccession": "E-MTAB-2836",
+          "experimentDescription": "RNA-seq of coding RNA from tissue samples of 122 human individuals representing 32 different tissues",
+          "lastUpdate": "05-10-2018",
+          "numberOfAssays": 200,
+          "numberOfContrasts": 0,
+          "species": "Homo sapiens",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "organism part"
+          ],
+          "experimentProjects": [
+            "HCA"
+          ],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MTAB-2909",
+          "experimentDescription": "RNA-seq of lung and ileum samples at 1 and 3 days post infection (dpi) from ducks infected with either low pathogenic (H5N2) or highly pathogenic (H5N1) avian influenza",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 36,
+          "numberOfContrasts": 8,
+          "species": "Anas platyrhynchos",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "infect",
+            "organism part",
+            "time"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_BASELINE",
+          "experimentAccession": "E-MTAB-3827",
+          "experimentDescription": "Strand-specific RNA-Seq of rRNA-depleted total RNA from common types of cultured or uncultured primary cells of different haemopoetic lineages from healthy individuals in the BLUEPRINT epigenome project",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 66,
+          "numberOfContrasts": 0,
+          "species": "Homo sapiens",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "cell type"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MTAB-3834",
+          "experimentDescription": "Transcriptome profiling of contrasting rice genotypes in response to submergence during seed germination",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 12,
+          "numberOfContrasts": 1,
+          "species": "Oryza sativa",
+          "kingdom": "plants",
+          "experimentalFactors": [
+            "growth condition"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_BASELINE",
+          "experimentAccession": "E-MTAB-4401",
+          "experimentDescription": "Transcription profiling by high throughput sequencing of different tissues from Brachypodium distachyon (Bd21 inbred line)",
+          "lastUpdate": "05-10-2018",
+          "numberOfAssays": 11,
+          "numberOfContrasts": 0,
+          "species": "Brachypodium distachyon",
+          "kingdom": "plants",
+          "experimentalFactors": [
+            "organism part"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_BASELINE",
+          "experimentAccession": "E-MTAB-451",
+          "experimentDescription": "RNA-Seq of Schistosoma mansoni (flatworms) larva and adult individuals at different life-stages",
+          "lastUpdate": "06-10-2018",
+          "numberOfAssays": 11,
+          "numberOfContrasts": 0,
+          "species": "Schistosoma mansoni",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "developmental stage"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MTAB-4559",
+          "experimentDescription": "Genetic response of maize silk to pollen tubes growth in comparison to fungal invasion.",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 12,
+          "numberOfContrasts": 3,
+          "species": "Zea mays subsp. mays",
+          "kingdom": "plants",
+          "experimentalFactors": [
+            "organism part",
+            "stimulus"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MTAB-5128",
+          "experimentDescription": "Microarray analysis of the effect of ppGpp, cdiAMP, and cdiGMP on Saccharomyces cerevisiae",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 24,
+          "numberOfContrasts": 4,
+          "species": "Saccharomyces cerevisiae",
+          "kingdom": "fungi",
+          "experimentalFactors": [
+            "compound",
+            "genotype",
+            "phenotype"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [
+            "A-AFFY-47"
+          ],
+          "arrayDesignNames": [
+            "Affymetrix GeneChip Yeast Genome 2.0 Array [Yeast_2]"
           ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_BASELINE",
-          "experimentAccession":"E-MTAB-2770",
-          "experimentDescription":"RNA-seq of 934 human cancer cell lines from the Cancer Cell Line Encyclopedia",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":934,
-          "numberOfContrasts":0,
-          "species":"Homo sapiens",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "cell line",
-              "disease"
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_BASELINE",
+          "experimentAccession": "E-MTAB-5200",
+          "experimentDescription": "The International Cancer Genome project: Pan-Cancer Analysis of Whole Genomes (PCAWG)",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 3372,
+          "numberOfContrasts": 0,
+          "species": "Homo sapiens",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "disease",
+            "organism part"
           ],
-          "arrayDesigns":[
-
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_BASELINE",
+          "experimentAccession": "E-MTAB-5214",
+          "experimentDescription": "RNA-seq from 53 human tissue samples from the Genotype-Tissue Expression (GTEx) Project",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 18736,
+          "numberOfContrasts": 0,
+          "species": "Homo sapiens",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "organism part"
           ],
-          "arrayDesignNames":[
-
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MTAB-5422",
+          "experimentDescription": "Altered expression of maize PLASTOCHRON1 enhances biomass and seed yield by extending cell division duration",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 12,
+          "numberOfContrasts": 2,
+          "species": "Zea mays",
+          "kingdom": "plants",
+          "experimentalFactors": [
+            "age",
+            "genotype"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_BASELINE",
+          "experimentAccession": "E-MTAB-5423",
+          "experimentDescription": "The International Cancer Genome project: Pan-Cancer Analysis of Whole Genomes (PCAWG)- Alternative view by individual",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 1359,
+          "numberOfContrasts": 0,
+          "species": "Homo sapiens",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "organism part",
+            "disease",
+            "individual"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MTAB-5633",
+          "experimentDescription": "Changes in the coding/non-coding transcriptome and DNA methylome that define the Schwann cell repair phenotype after nerve injury",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 6,
+          "numberOfContrasts": 1,
+          "species": "Mus musculus domesticus",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "injury",
+            "protocol",
+            "time"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "RNASEQ_MRNA_DIFFERENTIAL",
+          "experimentAccession": "E-MTAB-5941",
+          "experimentDescription": "Transcriptome profiling of short-term response to chilling stress in resistant and susceptible rice seedlings",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 18,
+          "numberOfContrasts": 7,
+          "species": "Oryza sativa Japonica Group",
+          "kingdom": "plants",
+          "experimentalFactors": [
+            "cultivar",
+            "environmental stress",
+            "time"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "PROTEOMICS_BASELINE",
+          "experimentAccession": "E-PROT-1",
+          "experimentDescription": "Reanalysis of Pandey lab\u0027s draft of the human proteome",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 30,
+          "numberOfContrasts": 0,
+          "species": "Homo sapiens",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "developmental stage",
+            "organism part"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [],
+          "arrayDesignNames": []
+        },
+        {
+          "experimentType": "MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL",
+          "experimentAccession": "E-TABM-713",
+          "experimentDescription": "MicroRNA profiling by array of human sepsis patients after surgery identifies miR-150 as a plasma prognostic marker",
+          "lastUpdate": "25-09-2018",
+          "numberOfAssays": 16,
+          "numberOfContrasts": 1,
+          "species": "Homo sapiens",
+          "kingdom": "animals",
+          "experimentalFactors": [
+            "disease"
+          ],
+          "experimentProjects": [],
+          "arrayDesigns": [
+            "A-MEXP-1551"
+          ],
+          "arrayDesignNames": [
+            "Agilent Human miRNA Microarray 8 X 15K 016436 G4470A 96 cols x 164 rows"
           ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_BASELINE",
-          "experimentAccession":"E-MTAB-2836",
-          "experimentDescription":"RNA-seq of coding RNA from tissue samples of 122 human individuals representing 32 different tissues",
-          "lastUpdate":"05-10-2018",
-          "numberOfAssays":200,
-          "numberOfContrasts":0,
-          "species":"Homo sapiens",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "organism part"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MTAB-2909",
-          "experimentDescription":"RNA-seq of lung and ileum samples at 1 and 3 days post infection (dpi) from ducks infected with either low pathogenic (H5N2) or highly pathogenic (H5N1) avian influenza",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":36,
-          "numberOfContrasts":8,
-          "species":"Anas platyrhynchos",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "infect",
-              "organism part",
-              "time"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_BASELINE",
-          "experimentAccession":"E-MTAB-3827",
-          "experimentDescription":"Strand-specific RNA-Seq of rRNA-depleted total RNA from common types of cultured or uncultured primary cells of different haemopoetic lineages from healthy individuals in the BLUEPRINT epigenome project",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":66,
-          "numberOfContrasts":0,
-          "species":"Homo sapiens",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "cell type"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MTAB-3834",
-          "experimentDescription":"Transcriptome profiling of contrasting rice genotypes in response to submergence during seed germination",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":12,
-          "numberOfContrasts":1,
-          "species":"Oryza sativa",
-          "kingdom":"plants",
-          "experimentalFactors":[
-              "growth condition"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_BASELINE",
-          "experimentAccession":"E-MTAB-4401",
-          "experimentDescription":"Transcription profiling by high throughput sequencing of different tissues from Brachypodium distachyon (Bd21 inbred line)",
-          "lastUpdate":"05-10-2018",
-          "numberOfAssays":11,
-          "numberOfContrasts":0,
-          "species":"Brachypodium distachyon",
-          "kingdom":"plants",
-          "experimentalFactors":[
-              "organism part"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_BASELINE",
-          "experimentAccession":"E-MTAB-451",
-          "experimentDescription":"RNA-Seq of Schistosoma mansoni (flatworms) larva and adult individuals at different life-stages",
-          "lastUpdate":"06-10-2018",
-          "numberOfAssays":11,
-          "numberOfContrasts":0,
-          "species":"Schistosoma mansoni",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "developmental stage"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MTAB-4559",
-          "experimentDescription":"Genetic response of maize silk to pollen tubes growth in comparison to fungal invasion.",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":12,
-          "numberOfContrasts":3,
-          "species":"Zea mays subsp. mays",
-          "kingdom":"plants",
-          "experimentalFactors":[
-              "organism part",
-              "stimulus"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MTAB-5128",
-          "experimentDescription":"Microarray analysis of the effect of ppGpp, cdiAMP, and cdiGMP on Saccharomyces cerevisiae",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":24,
-          "numberOfContrasts":4,
-          "species":"Saccharomyces cerevisiae",
-          "kingdom":"fungi",
-          "experimentalFactors":[
-              "compound",
-              "genotype",
-              "phenotype"
-          ],
-          "arrayDesigns":[
-              "A-AFFY-47"
-          ],
-          "arrayDesignNames":[
-              "Affymetrix GeneChip Yeast Genome 2.0 Array [Yeast_2]"
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_BASELINE",
-          "experimentAccession":"E-MTAB-5200",
-          "experimentDescription":"The International Cancer Genome project: Pan-Cancer Analysis of Whole Genomes (PCAWG)",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":3372,
-          "numberOfContrasts":0,
-          "species":"Homo sapiens",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "disease",
-              "organism part"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_BASELINE",
-          "experimentAccession":"E-MTAB-5214",
-          "experimentDescription":"RNA-seq from 53 human tissue samples from the Genotype-Tissue Expression (GTEx) Project",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":18736,
-          "numberOfContrasts":0,
-          "species":"Homo sapiens",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "organism part"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MTAB-5422",
-          "experimentDescription":"Altered expression of maize PLASTOCHRON1 enhances biomass and seed yield by extending cell division duration",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":12,
-          "numberOfContrasts":2,
-          "species":"Zea mays",
-          "kingdom":"plants",
-          "experimentalFactors":[
-              "age",
-              "genotype"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_BASELINE",
-          "experimentAccession":"E-MTAB-5423",
-          "experimentDescription":"The International Cancer Genome project: Pan-Cancer Analysis of Whole Genomes (PCAWG)- Alternative view by individual",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":1359,
-          "numberOfContrasts":0,
-          "species":"Homo sapiens",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "organism part",
-              "disease",
-              "individual"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MTAB-5633",
-          "experimentDescription":"Changes in the coding/non-coding transcriptome and DNA methylome that define the Schwann cell repair phenotype after nerve injury",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":6,
-          "numberOfContrasts":1,
-          "species":"Mus musculus domesticus",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "injury",
-              "protocol",
-              "time"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"RNASEQ_MRNA_DIFFERENTIAL",
-          "experimentAccession":"E-MTAB-5941",
-          "experimentDescription":"Transcriptome profiling of short-term response to chilling stress in resistant and susceptible rice seedlings",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":18,
-          "numberOfContrasts":7,
-          "species":"Oryza sativa Japonica Group",
-          "kingdom":"plants",
-          "experimentalFactors":[
-              "cultivar",
-              "environmental stress",
-              "time"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"PROTEOMICS_BASELINE",
-          "experimentAccession":"E-PROT-1",
-          "experimentDescription":"Reanalysis of Pandey lab\u0027s draft of the human proteome",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":30,
-          "numberOfContrasts":0,
-          "species":"Homo sapiens",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "developmental stage",
-              "organism part"
-          ],
-          "arrayDesigns":[
-
-          ],
-          "arrayDesignNames":[
-
-          ]
-      },
-      {
-          "experimentType":"MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL",
-          "experimentAccession":"E-TABM-713",
-          "experimentDescription":"MicroRNA profiling by array of human sepsis patients after surgery identifies miR-150 as a plasma prognostic marker",
-          "lastUpdate":"25-09-2018",
-          "numberOfAssays":16,
-          "numberOfContrasts":1,
-          "species":"Homo sapiens",
-          "kingdom":"animals",
-          "experimentalFactors":[
-              "disease"
-          ],
-          "arrayDesigns":[
-              "A-MEXP-1551"
-          ],
-          "arrayDesignNames":[
-              "Agilent Human miRNA Microarray 8 X 15K 016436 G4470A 96 cols x 164 rows"
-          ]
-      }
-  ]}
-  , 'target');
+        }
+      ]
+    }
+    , 'target')
 </script>
 
 </html>

--- a/html/index-sc.html
+++ b/html/index-sc.html
@@ -3,15 +3,20 @@
 <head>
     <title>Demo</title>
 
-    <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/libraries/foundation-6/css/foundation.css" type="text/css" media="all" />
-    <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/css/ebi-global.css" type="text/css" media="all" />
-    <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
-    <link rel="stylesheet" href="https://www.ebi.ac.uk/gxa/sc/resources/css/theme-atlas.css" type="text/css" media="all">
+    <link rel="stylesheet"
+          href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/libraries/foundation-6/css/foundation.css"
+          type="text/css" media="all"/>
+    <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/css/ebi-global.css"
+          type="text/css" media="all"/>
+    <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css"
+          type="text/css" media="all"/>
+    <link rel="stylesheet" href="https://www.ebi.ac.uk/gxa/sc/resources/css/theme-atlas.css" type="text/css"
+          media="all">
 </head>
 
 <body>
 <div id="wrapper" class="row expanded">
-    <div id="content" class="small-12 columns" >
+    <div id="content" class="small-12 columns">
         <div id="target">
         </div>
     </div>
@@ -26,873 +31,955 @@
     host: 'http://ves-hx-77:8080/gxa/sc/',
     resource: 'json/experiments',
     //link to `${host}/${header.resource}/${data[header.link]}/${header.endpoint}`
-      species: `homo sapiens`,
-     downloadTooltip: `<ul>
+    species: `homo sapiens`,
+    downloadTooltip: `<ul>
           <li>Raw filtered count matrix after quantification</li>
           <li>Normalised filtered count matrix after quantification</li>
           <li>TPM (transcripts per million RNA molecules - only available for SmartSeq)</li>
           <li>SDRF file with the experimental design metadata</li>
         </ul>`,
-      tableHeader:
-        [
-          //{title: `index`, width: 60, dataParam: null, link: null},
-          {type: `sort`, title: `Loaded date`, width: 240, dataParam: `lastUpdate`},
-          {type: `search`, title: `species`, width: 260, dataParam: `species`},
-          {type: `search`, title: `experiment description`, width: 460, dataParam: `experimentDescription`,
-            link: `experimentAccession`, resource: `experiments`, endpoint: `Results`},
-          {type: `search`, title: `experiment factors`, width: 260, dataParam: `experimentalFactors`},
-          {type: `sort`, title: `Number of assays`, width: 260, dataParam: `numberOfAssays`,
-            link: `experimentAccession`, resource: `experiments`, endpoint: `Experiment%20Design`},
-          //{ title: `Download`, width: null,  dataParam: null}
-        ],
-    noResultsMessageFormatter: function(data) { return 'Your search yielded no results: ' + data.reason },
+    tableHeader:
+      [
+        //{title: `index`, width: 60, dataParam: null, link: null},
+        {type: `sort`, title: `Loaded date`, width: 240, dataParam: `lastUpdate`},
+        {type: `search`, title: `species`, width: 260, dataParam: `species`},
+        {
+          type: `search`, title: `experiment description`, width: 460, dataParam: `experimentDescription`,
+          link: `experimentAccession`, resource: `experiments`, endpoint: `Results`
+        },
+        {type: `search`, title: `experiment factors`, width: 260, dataParam: `experimentalFactors`},
+        {
+          type: `sort`, title: `Number of assays`, width: 260, dataParam: `numberOfAssays`,
+          link: `experimentAccession`, resource: `experiments`, endpoint: `Experiment%20Design`
+        },
+        //{ title: `Download`, width: null,  dataParam: null}
+      ],
+    noResultsMessageFormatter: function (data) {
+      return 'Your search yielded no results: ' + data.reason
+    },
     enableDownload: true,
-      aaData: [
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-EHCA-2",
-              "experimentDescription": "Melanoma infiltration of stromal and immune cells",
-              "lastUpdate": "15-06-2019",
-              "numberOfAssays": 6638,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "sampling site",
-                  "time"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-ENAD-13",
-              "experimentDescription": "Single-cell RNA-seq analysis of 1,522 cells of the small intestinal epithelium",
-              "lastUpdate": "25-05-2019",
-              "numberOfAssays": 1521,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-ENAD-14",
-              "experimentDescription": "Single-cell RNA-seq analysis of 389 cells of the small intestinal epithelium in response to Salmonella enterica and to the parasitic helminth Heligmosomoides polygyrus",
-              "lastUpdate": "25-05-2019",
-              "numberOfAssays": 387,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "infect",
-                  "time"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-ENAD-16",
-              "experimentDescription": "Single cell transcriptomics of mixed asexual and sexual blood stage parasites of the rodent malaria model Plasmodium berghei",
-              "lastUpdate": "07-08-2018",
-              "numberOfAssays": 188,
-              "numberOfContrasts": 0,
-              "species": "Plasmodium berghei",
-              "kingdom": "protists",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-ENAD-17",
-              "experimentDescription": "Single cell RNA-seq of glioblastoma cells from five primary tumors",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 672,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-ENAD-18",
-              "experimentDescription": "Single cell RNA-seq of Schistosoma mansoni stem cells from in vitro-transformed mother sporocysts",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 35,
-              "numberOfContrasts": 0,
-              "species": "Schistosoma mansoni",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-ENAD-19",
-              "experimentDescription": "Single-cell RNA-sequencing of FACS sorted single blood cells from Anopheles gambiae",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 26,
-              "numberOfContrasts": 0,
-              "species": "Anopheles gambiae",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-ENAD-20",
-              "experimentDescription": "Single-cell RNA-seq analysis of a patient-derived xenograft model before and after treatment with BRAF and MEK inhibitors",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 674,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "compound",
-                  "time"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-ENAD-21",
-              "experimentDescription": "Single-cell RNA-seq analysis of adult human breast epithelial cells",
-              "lastUpdate": "05-11-2018",
-              "numberOfAssays": 867,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "cell type"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-100058",
-              "experimentDescription": "Single-cell RNA-seq analysis of Drosophila olfactory projection neurons",
-              "lastUpdate": "25-05-2018",
-              "numberOfAssays": 1842,
-              "numberOfContrasts": 0,
-              "species": "Drosophila melanogaster",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "cell type"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-100426",
-              "experimentDescription": "Single-cell RNA-seq of long-term hematopoietic stem cells from young and aged mouse in response to inflammatory stress",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 2111,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "cell type",
-                  "age",
-                  "stimulus"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-100618",
-              "experimentDescription": "Single-cell RNA-sequencing of human haemopoietic lympho-myeloid progenitor populations",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 415,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "cell type"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-100911",
-              "experimentDescription": "Single-cell RNA-seq analysis of kidney marrow from six zebrafish transgenic lines that label specific blood cell types",
-              "lastUpdate": "25-05-2018",
-              "numberOfAssays": 246,
-              "numberOfContrasts": 0,
-              "species": "Danio rerio",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "cell type"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-103011",
-              "experimentDescription": "Single cell RNA-seq of female rat ventral mesenchymal pad and adjacent urethra",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 115,
-              "numberOfContrasts": 0,
-              "species": "Rattus norvegicus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "organism part"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-103334",
-              "experimentDescription": "Single cell RNA-seq of microglia cells isolated from the hippocampus of a mouse model of severe neurodegeneration with AD-like phenotypes ",
-              "lastUpdate": "25-05-2018",
-              "numberOfAssays": 2208,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "genotype",
-                  "time"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-106540",
-              "experimentDescription": "Single-cell transcriptome analysis of precursors of human CD4+ cytotoxic T lymphocytes",
-              "lastUpdate": "25-05-2018",
-              "numberOfAssays": 2244,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "cell subtype",
-                  "clinical information",
-                  "genotype"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-106973",
-              "experimentDescription": "Single cell RNA sequencing of murine basophil/mast cell progenitors and granulocyte/monocyte progenitors",
-              "lastUpdate": "25-05-2018",
-              "numberOfAssays": 141,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "cell type"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-109159",
-              "experimentDescription": "Single-cell RNA-seq analysis of larval zebrafish habenula from the gng8-GFP transgenic line",
-              "lastUpdate": "25-05-2018",
-              "numberOfAssays": 1140,
-              "numberOfContrasts": 0,
-              "species": "Danio rerio",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-109796",
-              "experimentDescription": "Single cell RNA-seq of three regions in the mouse subpallium across two stages that coincide with the peak of neurogenesis for cortical interneurons",
-              "lastUpdate": "25-05-2018",
-              "numberOfAssays": 2668,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "organism part",
-                  "developmental stage"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-109979",
-              "experimentDescription": "Single-cell RNA-seq of human H9 cells undergoing definitive endoderm differentiation ",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 329,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "time"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-110499",
-              "experimentDescription": "Single cell RNA-seq of bone marrow biopsies of a multiple myeloma patient",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 173,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "organism part"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-111727",
-              "experimentDescription": "Single cell RNA-seq of a primary model of HIV latency and CD4+ T cells isolated from HIV-infected individuals",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 384,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "disease",
-                  "stimulus"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-70580",
-              "experimentDescription": "Single-cell RNA-seq analysis of human tonsil innate lymphoid cells",
-              "lastUpdate": "25-05-2018",
-              "numberOfAssays": 648,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "cell type"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-71585",
-              "experimentDescription": "Single-cell RNA-seq analysis of adult male mice primary visual cortex cells",
-              "lastUpdate": "25-05-2018",
-              "numberOfAssays": 1809,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "organism part",
-                  "phenotype"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-75688",
-              "experimentDescription": "Single cell RNA-seq of primary breast cancer cells and lymph node metastases from 11 patients representing the four subtypes of breast cancer: luminal A, luminal B, HER2 and triple negative breast cancer ",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 540,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "histology",
-                  "sampling site"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-77944",
-              "experimentDescription": "Single-cell transcriptomes of each cell of the C. elegans embryo until the 16-cell stage",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 219,
-              "numberOfContrasts": 0,
-              "species": "Caenorhabditis elegans",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "developmental stage"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-81383",
-              "experimentDescription": "Single cell RNA-seq of three human melanoma cell lines: Ma-Mel-123, Ma-Mel-108 and Ma-Mel-93",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 226,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-81547",
-              "experimentDescription": "Single cell transcriptome analysis of human pancreas",
-              "lastUpdate": "26-05-2018",
-              "numberOfAssays": 2544,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-81608",
-              "experimentDescription": "Single cell RNA-seq of human islet cells from non diabetic and type II diabetes organ donors",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 1600,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "disease"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-81682",
-              "experimentDescription": "Single cell RNA sequencing of mouse hematopoietic stem and progenitor cells ",
-              "lastUpdate": "26-05-2018",
-              "numberOfAssays": 1920,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "cell type"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-84465",
-              "experimentDescription": "Single-Cell RNAseq analysis of diffuse neoplastic infiltrating cells at the migrating front of human glioblastoma",
-              "lastUpdate": "26-05-2018",
-              "numberOfAssays": 3588,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "biopsy site"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-86618",
-              "experimentDescription": "Single cell RNA-seq of human lung epithelial cells from 3 control and 6 idiopathic pulmonary fibrosis patient samples",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 540,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "disease"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-87631",
-              "experimentDescription": "Single-cell RNA-seq analysis of young and old murine hematopoietic stem cells",
-              "lastUpdate": "26-05-2018",
-              "numberOfAssays": 1152,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "genotype",
-                  "age"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-89232",
-              "experimentDescription": "Single-cell RNA-seq analysis of primary human conventional dendritic cells, as well as cord blood and blood pre-conventional dendritic cells",
-              "lastUpdate": "26-05-2018",
-              "numberOfAssays": 957,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-90848",
-              "experimentDescription": "Single-cell RNA-seq of purified populations of stem cells and transit-amplifying cells of hair follicles",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 1119,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "age",
-                  "genotype"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-93593",
-              "experimentDescription": "Single-cell RNA-seq analysis of 1,732 cells throughout a 125-day differentiation protocol that converted H1 human embryonic stem cells to a variety of ventrally-derived cell types.",
-              "lastUpdate": "26-05-2018",
-              "numberOfAssays": 1733,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "phenotype",
-                  "time"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-98816",
-              "experimentDescription": "Single cell RNA-seq of mouse brain vascular transcriptomes",
-              "lastUpdate": "26-05-2018",
-              "numberOfAssays": 3186,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-99058",
-              "experimentDescription": "Single cell RNA-seq of mouse brain astrocyte transcriptomes",
-              "lastUpdate": "26-05-2018",
-              "numberOfAssays": 250,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-99235",
-              "experimentDescription": "Single cell RNA-seq of mouse lung vascular transcriptomes",
-              "lastUpdate": "26-05-2018",
-              "numberOfAssays": 1504,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-GEOD-99795",
-              "experimentDescription": "Single cell RNA-seq of human LNCaP prostate carcinoma cells cultured in the absence and presence of androgen for 12 hours",
-              "lastUpdate": "06-09-2018",
-              "numberOfAssays": 144,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "compound",
-                  "dose",
-                  "time"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-4850",
-              "experimentDescription": "Transcriptomic profiling of antigen-specific T cells at the single-cell level after clearance of hepatitis C virus",
-              "lastUpdate": "24-12-2018",
-              "numberOfAssays": 72,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "cell line",
-                  "stimulus",
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-4888",
-              "experimentDescription": "RNA-seq of coding RNA from single cells to assess the impact of aging on cell-to-cell transcriptional variability during immune stimulation",
-              "lastUpdate": "24-09-2018",
-              "numberOfAssays": 4032,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "strain",
-                  "age",
-                  "stimulus",
-                  "cell type"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-5061",
-              "experimentDescription": "Single-cell RNA-seq analysis of human pancreas from healthy individuals and type 2 diabetes patients",
-              "lastUpdate": "26-05-2018",
-              "numberOfAssays": 3514,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier",
-                  "disease"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-5485",
-              "experimentDescription": "Single cell RNA-sequencing of Spike-ins and mESC using Smart-Seq2  on C1 System",
-              "lastUpdate": "24-12-2018",
-              "numberOfAssays": 96,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-5530",
-              "experimentDescription": "Single-cell RNA-Seq data of zebrafish blood cells",
-              "lastUpdate": "24-09-2018",
-              "numberOfAssays": 2015,
-              "numberOfContrasts": 0,
-              "species": "Danio rerio",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "genotype",
-                  "organism part",
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-6077",
-              "experimentDescription": "Determining single-cell mRNA expression profiles of a specific population isolated from zebrafish embryos at 10 hours post fertilization",
-              "lastUpdate": "24-09-2018",
-              "numberOfAssays": 102,
-              "numberOfContrasts": 0,
-              "species": "Danio rerio",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "phenotype",
-                  "single cell identifier",
-                  "block"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-6142",
-              "experimentDescription": "Transcriptomic characterization of the human cell cycle in individual unsynchronized cells",
-              "lastUpdate": "02-08-2018",
-              "numberOfAssays": 96,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "cell cycle phase",
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-6362",
-              "experimentDescription": "Single-cell RNA-seq of mouse embryonic stem cells to study the genomic encoding of transcriptional burst kinetics",
-              "lastUpdate": "12-11-2018",
-              "numberOfAssays": 336,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "genotype",
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-6379",
-              "experimentDescription": "Single-cell RNAseq of Human T lymphocyte derived from H7N9 infected patients",
-              "lastUpdate": "12-06-2018",
-              "numberOfAssays": 119,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "clinical history",
-                  "sampling time point",
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-6818",
-              "experimentDescription": "Single-cell RNA-seq of de-differentiated mammary adipocytes during lactation",
-              "lastUpdate": "11-10-2018",
-              "numberOfAssays": 76,
-              "numberOfContrasts": 0,
-              "species": "Mus musculus",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "phenotype",
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-6819",
-              "experimentDescription": "Single-cell RNA-seq of naive and primed human embryonic stem cells",
-              "lastUpdate": "07-09-2018",
-              "numberOfAssays": 1344,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "phenotype",
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          },
-          {
-              "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
-              "experimentAccession": "E-MTAB-7303",
-              "experimentDescription": "Single cell sequencing of iPSC-dopamine neurons reconstructs disease progression and identifies HDAC4 as a regulator of Parkinson cell phenotypes",
-              "lastUpdate": "25-10-2018",
-              "numberOfAssays": 568,
-              "numberOfContrasts": 0,
-              "species": "Homo sapiens",
-              "kingdom": "animals",
-              "experimentalFactors": [
-                  "disease",
-                  "single cell identifier"
-              ],
-              "arrayDesigns": [],
-              "arrayDesignNames": []
-          }
-      ]
-     }, 'target');
+    aaData: [
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-EHCA-2",
+        "experimentDescription": "Melanoma infiltration of stromal and immune cells",
+        "lastUpdate": "15-06-2019",
+        "numberOfAssays": 6638,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "sampling site",
+          "time"
+        ],
+        "experimentProjects": [
+          "HCA"
+        ],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-ENAD-13",
+        "experimentDescription": "Single-cell RNA-seq analysis of 1,522 cells of the small intestinal epithelium",
+        "lastUpdate": "25-05-2019",
+        "numberOfAssays": 1521,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-ENAD-14",
+        "experimentDescription": "Single-cell RNA-seq analysis of 389 cells of the small intestinal epithelium in response to Salmonella enterica and to the parasitic helminth Heligmosomoides polygyrus",
+        "lastUpdate": "25-05-2019",
+        "numberOfAssays": 387,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "infect",
+          "time"
+        ],
+        "experimentProjects": [
+          "HCA"
+        ],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-ENAD-16",
+        "experimentDescription": "Single cell transcriptomics of mixed asexual and sexual blood stage parasites of the rodent malaria model Plasmodium berghei",
+        "lastUpdate": "07-08-2018",
+        "numberOfAssays": 188,
+        "numberOfContrasts": 0,
+        "species": "Plasmodium berghei",
+        "kingdom": "protists",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-ENAD-17",
+        "experimentDescription": "Single cell RNA-seq of glioblastoma cells from five primary tumors",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 672,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-ENAD-18",
+        "experimentDescription": "Single cell RNA-seq of Schistosoma mansoni stem cells from in vitro-transformed mother sporocysts",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 35,
+        "numberOfContrasts": 0,
+        "species": "Schistosoma mansoni",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-ENAD-19",
+        "experimentDescription": "Single-cell RNA-sequencing of FACS sorted single blood cells from Anopheles gambiae",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 26,
+        "numberOfContrasts": 0,
+        "species": "Anopheles gambiae",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-ENAD-20",
+        "experimentDescription": "Single-cell RNA-seq analysis of a patient-derived xenograft model before and after treatment with BRAF and MEK inhibitors",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 674,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "compound",
+          "time"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-ENAD-21",
+        "experimentDescription": "Single-cell RNA-seq analysis of adult human breast epithelial cells",
+        "lastUpdate": "05-11-2018",
+        "numberOfAssays": 867,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "cell type"
+        ],
+        "experimentProjects": [
+          "HCA"
+        ],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-100058",
+        "experimentDescription": "Single-cell RNA-seq analysis of Drosophila olfactory projection neurons",
+        "lastUpdate": "25-05-2018",
+        "numberOfAssays": 1842,
+        "numberOfContrasts": 0,
+        "species": "Drosophila melanogaster",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "cell type"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-100426",
+        "experimentDescription": "Single-cell RNA-seq of long-term hematopoietic stem cells from young and aged mouse in response to inflammatory stress",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 2111,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "cell type",
+          "age",
+          "stimulus"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-100618",
+        "experimentDescription": "Single-cell RNA-sequencing of human haemopoietic lympho-myeloid progenitor populations",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 415,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "cell type"
+        ],
+        "experimentProjects": [
+          "HCA",
+          "CZ-Biohub"
+        ],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-100911",
+        "experimentDescription": "Single-cell RNA-seq analysis of kidney marrow from six zebrafish transgenic lines that label specific blood cell types",
+        "lastUpdate": "25-05-2018",
+        "numberOfAssays": 246,
+        "numberOfContrasts": 0,
+        "species": "Danio rerio",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "cell type"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-103011",
+        "experimentDescription": "Single cell RNA-seq of female rat ventral mesenchymal pad and adjacent urethra",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 115,
+        "numberOfContrasts": 0,
+        "species": "Rattus norvegicus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "organism part"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-103334",
+        "experimentDescription": "Single cell RNA-seq of microglia cells isolated from the hippocampus of a mouse model of severe neurodegeneration with AD-like phenotypes ",
+        "lastUpdate": "25-05-2018",
+        "numberOfAssays": 2208,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "genotype",
+          "time"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-106540",
+        "experimentDescription": "Single-cell transcriptome analysis of precursors of human CD4+ cytotoxic T lymphocytes",
+        "lastUpdate": "25-05-2018",
+        "numberOfAssays": 2244,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "cell subtype",
+          "clinical information",
+          "genotype"
+        ],
+        "experimentProjects": [
+          "HCA",
+          "CZ-Biohub"
+        ],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-106973",
+        "experimentDescription": "Single cell RNA sequencing of murine basophil/mast cell progenitors and granulocyte/monocyte progenitors",
+        "lastUpdate": "25-05-2018",
+        "numberOfAssays": 141,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "cell type"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-109159",
+        "experimentDescription": "Single-cell RNA-seq analysis of larval zebrafish habenula from the gng8-GFP transgenic line",
+        "lastUpdate": "25-05-2018",
+        "numberOfAssays": 1140,
+        "numberOfContrasts": 0,
+        "species": "Danio rerio",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-109796",
+        "experimentDescription": "Single cell RNA-seq of three regions in the mouse subpallium across two stages that coincide with the peak of neurogenesis for cortical interneurons",
+        "lastUpdate": "25-05-2018",
+        "numberOfAssays": 2668,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "organism part",
+          "developmental stage"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-109979",
+        "experimentDescription": "Single-cell RNA-seq of human H9 cells undergoing definitive endoderm differentiation ",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 329,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "time"
+        ],
+        "experimentProjects": [
+          "HCA",
+          "CZ-Biohub",
+          "Malaria-Cell-Atlas"
+        ],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-110499",
+        "experimentDescription": "Single cell RNA-seq of bone marrow biopsies of a multiple myeloma patient",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 173,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "organism part"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-111727",
+        "experimentDescription": "Single cell RNA-seq of a primary model of HIV latency and CD4+ T cells isolated from HIV-infected individuals",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 384,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "disease",
+          "stimulus"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-70580",
+        "experimentDescription": "Single-cell RNA-seq analysis of human tonsil innate lymphoid cells",
+        "lastUpdate": "25-05-2018",
+        "numberOfAssays": 648,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "cell type"
+        ],
+        "experimentProjects": [
+          "HCA",
+          "CZ-Biohub"
+        ],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-71585",
+        "experimentDescription": "Single-cell RNA-seq analysis of adult male mice primary visual cortex cells",
+        "lastUpdate": "25-05-2018",
+        "numberOfAssays": 1809,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "organism part",
+          "phenotype"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-75688",
+        "experimentDescription": "Single cell RNA-seq of primary breast cancer cells and lymph node metastases from 11 patients representing the four subtypes of breast cancer: luminal A, luminal B, HER2 and triple negative breast cancer ",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 540,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "histology",
+          "sampling site"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-77944",
+        "experimentDescription": "Single-cell transcriptomes of each cell of the C. elegans embryo until the 16-cell stage",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 219,
+        "numberOfContrasts": 0,
+        "species": "Caenorhabditis elegans",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "developmental stage"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-81383",
+        "experimentDescription": "Single cell RNA-seq of three human melanoma cell lines: Ma-Mel-123, Ma-Mel-108 and Ma-Mel-93",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 226,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-81547",
+        "experimentDescription": "Single cell transcriptome analysis of human pancreas",
+        "lastUpdate": "26-05-2018",
+        "numberOfAssays": 2544,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-81608",
+        "experimentDescription": "Single cell RNA-seq of human islet cells from non diabetic and type II diabetes organ donors",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 1600,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "disease"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-81682",
+        "experimentDescription": "Single cell RNA sequencing of mouse hematopoietic stem and progenitor cells ",
+        "lastUpdate": "26-05-2018",
+        "numberOfAssays": 1920,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "cell type"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-84465",
+        "experimentDescription": "Single-Cell RNAseq analysis of diffuse neoplastic infiltrating cells at the migrating front of human glioblastoma",
+        "lastUpdate": "26-05-2018",
+        "numberOfAssays": 3588,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "biopsy site"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-86618",
+        "experimentDescription": "Single cell RNA-seq of human lung epithelial cells from 3 control and 6 idiopathic pulmonary fibrosis patient samples",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 540,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "disease"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-87631",
+        "experimentDescription": "Single-cell RNA-seq analysis of young and old murine hematopoietic stem cells",
+        "lastUpdate": "26-05-2018",
+        "numberOfAssays": 1152,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "genotype",
+          "age"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-89232",
+        "experimentDescription": "Single-cell RNA-seq analysis of primary human conventional dendritic cells, as well as cord blood and blood pre-conventional dendritic cells",
+        "lastUpdate": "26-05-2018",
+        "numberOfAssays": 957,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-90848",
+        "experimentDescription": "Single-cell RNA-seq of purified populations of stem cells and transit-amplifying cells of hair follicles",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 1119,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "age",
+          "genotype"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-93593",
+        "experimentDescription": "Single-cell RNA-seq analysis of 1,732 cells throughout a 125-day differentiation protocol that converted H1 human embryonic stem cells to a variety of ventrally-derived cell types.",
+        "lastUpdate": "26-05-2018",
+        "numberOfAssays": 1733,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "phenotype",
+          "time"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-98816",
+        "experimentDescription": "Single cell RNA-seq of mouse brain vascular transcriptomes",
+        "lastUpdate": "26-05-2018",
+        "numberOfAssays": 3186,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-99058",
+        "experimentDescription": "Single cell RNA-seq of mouse brain astrocyte transcriptomes",
+        "lastUpdate": "26-05-2018",
+        "numberOfAssays": 250,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-99235",
+        "experimentDescription": "Single cell RNA-seq of mouse lung vascular transcriptomes",
+        "lastUpdate": "26-05-2018",
+        "numberOfAssays": 1504,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-GEOD-99795",
+        "experimentDescription": "Single cell RNA-seq of human LNCaP prostate carcinoma cells cultured in the absence and presence of androgen for 12 hours",
+        "lastUpdate": "06-09-2018",
+        "numberOfAssays": 144,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "compound",
+          "dose",
+          "time"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-4850",
+        "experimentDescription": "Transcriptomic profiling of antigen-specific T cells at the single-cell level after clearance of hepatitis C virus",
+        "lastUpdate": "24-12-2018",
+        "numberOfAssays": 72,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "cell line",
+          "stimulus",
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-4888",
+        "experimentDescription": "RNA-seq of coding RNA from single cells to assess the impact of aging on cell-to-cell transcriptional variability during immune stimulation",
+        "lastUpdate": "24-09-2018",
+        "numberOfAssays": 4032,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "strain",
+          "age",
+          "stimulus",
+          "cell type"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-5061",
+        "experimentDescription": "Single-cell RNA-seq analysis of human pancreas from healthy individuals and type 2 diabetes patients",
+        "lastUpdate": "26-05-2018",
+        "numberOfAssays": 3514,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier",
+          "disease"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-5485",
+        "experimentDescription": "Single cell RNA-sequencing of Spike-ins and mESC using Smart-Seq2  on C1 System",
+        "lastUpdate": "24-12-2018",
+        "numberOfAssays": 96,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-5530",
+        "experimentDescription": "Single-cell RNA-Seq data of zebrafish blood cells",
+        "lastUpdate": "24-09-2018",
+        "numberOfAssays": 2015,
+        "numberOfContrasts": 0,
+        "species": "Danio rerio",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "genotype",
+          "organism part",
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-6077",
+        "experimentDescription": "Determining single-cell mRNA expression profiles of a specific population isolated from zebrafish embryos at 10 hours post fertilization",
+        "lastUpdate": "24-09-2018",
+        "numberOfAssays": 102,
+        "numberOfContrasts": 0,
+        "species": "Danio rerio",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "phenotype",
+          "single cell identifier",
+          "block"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-6142",
+        "experimentDescription": "Transcriptomic characterization of the human cell cycle in individual unsynchronized cells",
+        "lastUpdate": "02-08-2018",
+        "numberOfAssays": 96,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "cell cycle phase",
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-6362",
+        "experimentDescription": "Single-cell RNA-seq of mouse embryonic stem cells to study the genomic encoding of transcriptional burst kinetics",
+        "lastUpdate": "12-11-2018",
+        "numberOfAssays": 336,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "genotype",
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-6379",
+        "experimentDescription": "Single-cell RNAseq of Human T lymphocyte derived from H7N9 infected patients",
+        "lastUpdate": "12-06-2018",
+        "numberOfAssays": 119,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "clinical history",
+          "sampling time point",
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-6818",
+        "experimentDescription": "Single-cell RNA-seq of de-differentiated mammary adipocytes during lactation",
+        "lastUpdate": "11-10-2018",
+        "numberOfAssays": 76,
+        "numberOfContrasts": 0,
+        "species": "Mus musculus",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "phenotype",
+          "single cell identifier"
+        ],
+        "experimentProjects": [],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-6819",
+        "experimentDescription": "Single-cell RNA-seq of naive and primed human embryonic stem cells",
+        "lastUpdate": "07-09-2018",
+        "numberOfAssays": 1344,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "phenotype",
+          "single cell identifier"
+        ],
+        "experimentProjects": [
+          "HCA"
+        ],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      },
+      {
+        "experimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+        "experimentAccession": "E-MTAB-7303",
+        "experimentDescription": "Single cell sequencing of iPSC-dopamine neurons reconstructs disease progression and identifies HDAC4 as a regulator of Parkinson cell phenotypes",
+        "lastUpdate": "25-10-2018",
+        "numberOfAssays": 568,
+        "numberOfContrasts": 0,
+        "species": "Homo sapiens",
+        "kingdom": "animals",
+        "experimentalFactors": [
+          "disease",
+          "single cell identifier"
+        ],
+        "experimentProjects": [
+          "HCA",
+          "CZ-Biohub"
+        ],
+        "arrayDesigns": [],
+        "arrayDesignNames": []
+      }
+    ]
+  }, 'target')
 </script>
 
 </html>

--- a/html/index-sc.html
+++ b/html/index-sc.html
@@ -74,7 +74,7 @@
           "time"
         ],
         "experimentProjects": [
-          "HCA"
+          "Human Cell Atlas"
         ],
         "arrayDesigns": [],
         "arrayDesignNames": []
@@ -110,7 +110,7 @@
           "time"
         ],
         "experimentProjects": [
-          "HCA"
+          "Human Cell Atlas"
         ],
         "arrayDesigns": [],
         "arrayDesignNames": []
@@ -211,7 +211,7 @@
           "cell type"
         ],
         "experimentProjects": [
-          "HCA"
+          "Human Cell Atlas"
         ],
         "arrayDesigns": [],
         "arrayDesignNames": []
@@ -266,8 +266,8 @@
           "cell type"
         ],
         "experimentProjects": [
-          "HCA",
-          "CZ-Biohub"
+          "Human Cell Atlas",
+          "Chan-Zuckerberg Biohub"
         ],
         "arrayDesigns": [],
         "arrayDesignNames": []
@@ -340,8 +340,8 @@
           "genotype"
         ],
         "experimentProjects": [
-          "HCA",
-          "CZ-Biohub"
+          "Human Cell Atlas",
+          "Chan-Zuckerberg Biohub"
         ],
         "arrayDesigns": [],
         "arrayDesignNames": []
@@ -411,9 +411,9 @@
           "time"
         ],
         "experimentProjects": [
-          "HCA",
-          "CZ-Biohub",
-          "Malaria-Cell-Atlas"
+          "Human Cell Atlas",
+          "Chan-Zuckerberg Biohub",
+          "Malaria Cell Atlas"
         ],
         "arrayDesigns": [],
         "arrayDesignNames": []
@@ -467,8 +467,8 @@
           "cell type"
         ],
         "experimentProjects": [
-          "HCA",
-          "CZ-Biohub"
+          "Human Cell Atlas",
+          "Chan-Zuckerberg Biohub"
         ],
         "arrayDesigns": [],
         "arrayDesignNames": []
@@ -953,7 +953,7 @@
           "single cell identifier"
         ],
         "experimentProjects": [
-          "HCA"
+          "Human Cell Atlas"
         ],
         "arrayDesigns": [],
         "arrayDesignNames": []
@@ -972,8 +972,8 @@
           "single cell identifier"
         ],
         "experimentProjects": [
-          "HCA",
-          "CZ-Biohub"
+          "Human Cell Atlas",
+          "Chan-Zuckerberg Biohub"
         ],
         "arrayDesigns": [],
         "arrayDesignNames": []

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "author": "Expression Atlas developers <arrayexpress-atlas@ebi.ac.uk>",
   "collaborators": [
-    "Lingyun Zhao<lingyun@ebi.ac.uk>"
+    "Lingyun Zhao<lingyun@ebi.ac.uk>",
+    "Haider Iqbal<haideri@ebi.ac.uk>"
   ],
   "license": "Apache-2.0",
   "repository": {

--- a/src/ExperimentTable.js
+++ b/src/ExperimentTable.js
@@ -113,10 +113,10 @@ class ExperimentTable extends React.Component {
   }
 
   render() {
-    const {searchQuery, searchedColumnIndex, selectedSearch, selectedKingdom, selectedProject, checkedRows} = this.state
-    const {orderedColumnIndex, ascendingOrder} = this.state
-    const {entriesPerPage, currentPage} = this.state
-    const {host, aaData, tableHeader, enableDownload, downloadTooltip} = this.props
+    const { searchQuery, searchedColumnIndex, selectedSearch, selectedKingdom, selectedProject, checkedRows } = this.state
+    const { orderedColumnIndex, ascendingOrder } = this.state
+    const { entriesPerPage, currentPage } = this.state
+    const { host, aaData, tableHeader, enableDownload, downloadTooltip } = this.props
 
     const displayedFields = tableHeader.map(header => header.dataParam)
 

--- a/src/TableSearchHeader.js
+++ b/src/TableSearchHeader.js
@@ -1,17 +1,31 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const TableSearchHeader = ({kingdomOptions, entriesPerPageOptions, totalNumberOfRows, searchAllOnChange, numberOfEntriesPerPageOnChange, kingdomOnChange}) =>
+const TableSearchHeader = ({kingdomOptions, projectOptions, entriesPerPageOptions, totalNumberOfRows, searchAllOnChange, numberOfEntriesPerPageOnChange, kingdomOnChange, projectOnChange}) =>
   <div className={`row expanded`}>
+    <div className={`small-12 medium-4 large-2 columns`}>
+      <label> Project:
+        <select defaultValue={``} onChange={e => projectOnChange(e)}>
+          <option value={``}>All</option>
+          {
+            projectOptions.map(project =>
+              <option key={project} value={project}>
+                {project}
+              </option>)
+          }
+        </select>
+      </label>
+    </div>
+
     <div className={`small-12 medium-4 large-2 columns`}>
       <label> Kingdom:
         <select defaultValue={``} onChange={e => kingdomOnChange(e)}>
-          <option value={``} >All</option>
+          <option value={``}>All</option>
           {
             kingdomOptions.map(kingdom =>
               <option key={kingdom} value={kingdom}>
                 {kingdom.charAt(0).toUpperCase() + kingdom.slice(1)}
-              </option>) 
+              </option>)
           }
         </select>
       </label>
@@ -40,11 +54,13 @@ const TableSearchHeader = ({kingdomOptions, entriesPerPageOptions, totalNumberOf
 
 TableSearchHeader.propTypes = {
   kingdomOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  projectOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
   entriesPerPageOptions: PropTypes.array.isRequired,
   totalNumberOfRows: PropTypes.number.isRequired,
   searchAllOnChange: PropTypes.func.isRequired,
   numberOfEntriesPerPageOnChange: PropTypes.func.isRequired,
-  kingdomOnChange: PropTypes.func.isRequired
+  kingdomOnChange: PropTypes.func.isRequired,
+  projectOnChange: PropTypes.func.isRequired
 }
 
 export default TableSearchHeader


### PR DESCRIPTION
Add new project dropdown to filter experiments according to projects. Project information is sent in JSON payload as an array.