### PR TITLE
Feature/170000065 add dialogue window for file types

### DIFF
--- a/__test__/ExperimentTable.test.js
+++ b/__test__/ExperimentTable.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
-import { getRandomInt, TableCellDiv, data, tableHeader, tableFilters } from './TestUtils'
+import {getRandomInt, data, tableHeader, tableFilters, downloadFileTypes} from './TestUtils'
 import ExperimentTable from '../src/ExperimentTable'
 import TableFooter from '../src/TableFooter'
 import TableContent from '../src/TableContent'
@@ -11,13 +11,13 @@ import _ from 'lodash'
 describe(`ExperimentTable`, () => {
   const props = {
     experiments: data,
+    downloadFileTypes: downloadFileTypes,
     tableHeader: tableHeader,
     tableFilters: tableFilters,
     host: `fool`,
     resource: `bool`,
     enableDownload: true,
     enableIndex: true,
-    TableCellDiv: TableCellDiv,
     downloadTooltip: `<t>A random test tooltip text</t>`
   }
 

--- a/__test__/Prompt.test.js
+++ b/__test__/Prompt.test.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import Enzyme from 'enzyme'
+import {shallow, mount} from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+import Prompt from '../src/Prompt'
+import { downloadFileTypes } from './TestUtils'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+describe(`Prompt`, () => {
+  const props = {
+    downloadFileTypes: downloadFileTypes,
+    onSelect: () => {}
+  }
+
+  test(`should render 3 file type checkboxes and descriptions`, () => {
+    const wrapper = shallow(<Prompt {...props}/>)
+    expect(wrapper.find(`input`)).toHaveLength(downloadFileTypes.length)
+    expect(wrapper.find(`p`)).toHaveLength(downloadFileTypes.length + 1) //title
+  })
+
+  test(`should store selected/toggled file types when check boxes are clicked`, () => {
+    const wrapper = mount(<Prompt {...props}/>)
+    //all checked by default
+    expect(wrapper.state(`selectedFileTypes`)).toStrictEqual(downloadFileTypes.map(filtype => filtype.id))
+
+    //uncheck the first one
+    wrapper.find(`input`).first().simulate(`change`)
+    expect(wrapper.state(`selectedFileTypes`)).toStrictEqual([downloadFileTypes[1].id, downloadFileTypes[2].id])
+
+    //toggle the first one
+    wrapper.find(`input`).first().simulate(`change`)
+    expect(wrapper.state(`selectedFileTypes`)).toStrictEqual(downloadFileTypes.map(filtype => filtype.id))
+  })
+
+  test(`matches snapshot`, () => {
+    const tree = renderer.create(<Prompt {...props}/>).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/__test__/TableContent.test.js
+++ b/__test__/TableContent.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { data } from './TestUtils'
+import { data, downloadFileTypes } from './TestUtils'
 
 import TableContent from '../src/TableContent'
 import {alertInvalidFiles} from '../src/TableContent'
@@ -19,6 +19,7 @@ describe(`TableContent`, () => {
   })
 
   const props = {
+    downloadFileTypes: downloadFileTypes,
     enableIndex: true,
     tableHeader: [{
       type: `sort`,

--- a/__test__/TestUtils.js
+++ b/__test__/TestUtils.js
@@ -92,4 +92,19 @@ const data = [
   }
 ]
 
-export {getRandomInt, TableCellDiv, tableHeader, data, tableFilters}
+const downloadFileTypes = [
+  {
+    description: `File type 1`,
+    id: `file1`
+  },
+  {
+    description: `File type 2`,
+    id: `file-2`
+  },
+  {
+    description: `File type 3`,
+    id: `file-type3`
+  }
+]
+
+export {getRandomInt, TableCellDiv, tableHeader, data, tableFilters, downloadFileTypes}

--- a/__test__/__snapshots__/Prompt.test.js.snap
+++ b/__test__/__snapshots__/Prompt.test.js.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Prompt matches snapshot 1`] = `
+<div>
+  <p
+    style={
+      Object {
+        "paddingBottom": "1rem",
+      }
+    }
+  >
+    Choose file types...
+  </p>
+  <div
+    id="filetype0"
+    style={
+      Object {
+        "display": "flex",
+      }
+    }
+  >
+    <input
+      checked={true}
+      className="checkbox"
+      id="file1"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <p
+      id="File type 1"
+      style={
+        Object {
+          "paddingBottom": "1rem",
+          "paddingLeft": "1rem",
+        }
+      }
+    >
+      File type 1
+    </p>
+  </div>
+  <div
+    id="filetype1"
+    style={
+      Object {
+        "display": "flex",
+      }
+    }
+  >
+    <input
+      checked={true}
+      className="checkbox"
+      id="file-2"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <p
+      id="File type 2"
+      style={
+        Object {
+          "paddingBottom": "1rem",
+          "paddingLeft": "1rem",
+        }
+      }
+    >
+      File type 2
+    </p>
+  </div>
+  <div
+    id="filetype2"
+    style={
+      Object {
+        "display": "flex",
+      }
+    }
+  >
+    <input
+      checked={true}
+      className="checkbox"
+      id="file-type3"
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <p
+      id="File type 3"
+      style={
+        Object {
+          "paddingBottom": "1rem",
+          "paddingLeft": "1rem",
+        }
+      }
+    >
+      File type 3
+    </p>
+  </div>
+</div>
+`;

--- a/html/index-sc.html
+++ b/html/index-sc.html
@@ -12,6 +12,8 @@
           type="text/css" media="all"/>
     <link rel="stylesheet" href="https://www.ebi.ac.uk/gxa/sc/resources/css/theme-atlas.css" type="text/css"
           media="all">
+    <link rel="stylesheet" href="./react-popup.css" type="text/css" media="all">
+
 </head>
 
 <body>
@@ -38,6 +40,20 @@
           <li>TPM (transcripts per million RNA molecules - only available for SmartSeq)</li>
           <li>SDRF file with the experimental design metadata</li>
         </ul>`,
+    downloadFileTypes: [
+      {
+        description: `Raw quantification files`,
+        id: `quantification-raw`
+      },
+      {
+        description: `Normalised counts files`,
+        id: `normalised`
+      },
+      {
+        description: `Experiment design file`,
+        id: `experiment-design`
+      }
+    ],
     tableFilters: [
       {
         label: `Kingdom`,

--- a/html/react-popup.css
+++ b/html/react-popup.css
@@ -1,0 +1,201 @@
+.mm-popup {
+    display: none;
+}
+
+.mm-popup--visible {
+    display: block;
+}
+
+.mm-popup__overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    overflow: auto;
+    background: rgba(10, 10, 10, 0.45);
+}
+
+.mm-popup__close {
+    position: absolute;
+    top: 0.5rem;
+    right: 1rem;
+    padding: 0;
+    cursor: pointer;
+    text-align: center;
+    margin: 0;
+    font-size: 2em;
+    color: #8a8a8a;
+}
+
+.mm-popup__close:after {
+    content: '×';
+}
+
+.mm-popup__input {
+    display: block;
+    width: 100%;
+    height: 30px;
+    border-radius: 3px;
+    background: #f5f5f5;
+    border: 1px solid #e9ebec;
+    outline: none;
+    -moz-box-sizing: border-box !important;
+    -webkit-box-sizing: border-box !important;
+    box-sizing: border-box !important;
+    font-size: 14px;
+    padding: 0 12px;
+    color: #808080;
+}
+
+.mm-popup__btn {
+    border-radius: 0;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0.85em 1em;
+    margin: 0 0 1rem 0;
+    line-height: 1;
+    border: 1px solid #666;
+    text-align: center;
+    display: inline-block;
+    vertical-align: middle;
+    font-size: 0.9rem;
+    font-weight: 400;
+    color: #333;
+    background: transparent;
+    outline: none;
+    text-decoration: none;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.mm-popup__btn--success {
+    transition: background-color 0.25s ease-out, color 0.25s ease-out;
+    background-color: #3497c5;
+    border-color: #3497c5;
+    color: #fff;
+}
+
+.mm-popup__btn--success.primary:hover,
+.mm-popup__btn--success.primary:focus,
+.mm-popup__btn--success.hover,
+.mm-popup__btn--success:hover,
+.mm-popup__btn--success:focus,
+.mm-popup__btn--success:active {
+  background: #2f5767;
+}
+
+.mm-popup__btn--danger {
+    background-color: #c5545c;
+    border-color: #c5545c;
+    color: #fff;
+}
+
+.mm-popup__box {
+    width: 350px;
+    position: fixed;
+    top: 10%;
+    left: 50%;
+    margin-left: -175px;
+    background: #fff;
+    box-shadow: 0px 5px 20px 0px rgba(126, 137, 140, 0.20);
+    border: 1px solid #B8C8CC;
+    overflow: hidden;
+    z-index: 1001;
+}
+
+.mm-popup__box__header {
+    padding: 15px 20px;
+    color: #454B4D;
+}
+
+.mm-popup__box__header__title {
+    margin: 0;
+    font-size: 1.9375rem;
+    text-align: left;
+    font-weight: 400;
+    font-style: normal;
+    color:  #444444;
+}
+
+.mm-popup__box__body {
+    padding: 20px;
+    line-height: 1.4;
+    color: #454B4D;
+    background: #fff;
+    position: relative;
+    z-index: 2;
+}
+
+.mm-popup__box__body p {
+    margin: 0 0 5px;
+}
+
+.mm-popup__box__footer {
+    overflow: hidden;
+    padding: 0px 20px 20px;
+}
+
+.mm-popup__box__footer__right-space {
+    float: right;
+}
+
+.mm-popup__box__footer__right-space .mm-popup__btn {
+    margin-left: 5px;
+}
+
+.mm-popup__box__footer__left-space {
+    float: left;
+}
+
+.mm-popup__box__footer__left-space .mm-popup__btn {
+    margin-right: 5px;
+}
+
+.mm-popup__box--popover {
+    width: 300px;
+    margin-left: -150px;
+}
+
+.mm-popup__box--popover .mm-popup__close {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    padding: 0;
+    cursor: pointer;
+    outline: none;
+    text-align: center;
+    margin: 0;
+    z-index: 3;
+}
+
+.mm-popup__box--popover .mm-popup__box__body {
+    padding: 20px;
+}
+
+@media (max-width: 420px) {
+    .mm-popup__box {
+        width: auto;
+        left: 10px;
+        right: 10px;
+        top: 10px;
+        margin-left: 0;
+    }
+    .mm-popup__box__footer__left-space {
+        float: none;
+    }
+    .mm-popup__box__footer__right-space {
+        float: none;
+    }
+    .mm-popup__box__footer {
+        padding-top: 30px;
+    }
+    .mm-popup__box__footer .mm-popup__btn {
+        display: block;
+        width: 100%;
+        text-align: center;
+        margin-top: 10px;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "atlas-experiment-table",
+  "name": "@ebi-gene-expression-group/atlas-experiment-table",
   "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -1720,7 +1720,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -1842,7 +1842,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1984,7 +1984,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-preset-jest": {
@@ -2258,7 +2258,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -2266,7 +2266,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2303,7 +2303,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2858,7 +2858,7 @@
     },
     "core-js": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-js-compat": {
@@ -2910,7 +2910,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -2923,7 +2923,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2983,7 +2983,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -3258,7 +3258,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -4433,7 +4433,7 @@
       "dependencies": {
         "array-flatten": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
           "dev": true
         },
@@ -5609,7 +5609,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -7082,6 +7082,11 @@
       "resolved": "https://registry.npmjs.org/jw-paginate/-/jw-paginate-1.0.4.tgz",
       "integrity": "sha512-W0bv782exgCoynUL/egbRpaYwf/r6T6e02H870H5u3hfSgEYrxgz5POwmFF5aApS6iPi6yhZ0VF8IbafNFsntA=="
     },
+    "keymaster": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/keymaster/-/keymaster-1.6.2.tgz",
+      "integrity": "sha1-4a5U0OqUiPn2C2a2aPAumhlGxus="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -7377,7 +7382,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -7555,7 +7560,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -8076,7 +8081,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -8248,7 +8253,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -8717,6 +8722,14 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-popup": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/react-popup/-/react-popup-0.10.0.tgz",
+      "integrity": "sha512-NPO65MsAznv/JaP3MDz3DAqKJsA8fEcW5ttzTj6wGXtjPi0qDeB+f+hf4IbMcVrlJ2ZG4uHEdgL6B5QP/AGv3Q==",
+      "requires": {
+        "keymaster": "^1.6.2"
+      }
+    },
     "react-scrollbar-size": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-scrollbar-size/-/react-scrollbar-size-2.1.0.tgz",
@@ -8836,7 +8849,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -8960,7 +8973,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -9203,7 +9216,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -9441,7 +9454,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -9999,7 +10012,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -10031,7 +10044,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -10124,7 +10137,7 @@
     },
     "tapable": {
       "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+      "resolved": "http://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
       "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
       "dev": true
     },
@@ -10264,7 +10277,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -10405,7 +10418,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-popup": "^0.10.0",
     "react-tooltip": "^3.11.1",
     "styled-components": "^4.4.1",
     "urijs": "^1.19.2"

--- a/src/ExperimentTable.js
+++ b/src/ExperimentTable.js
@@ -154,7 +154,7 @@ class ExperimentTable extends React.Component {
     const { selectedDropdownFilters, experimentTableFilters } = this.state
     const { orderedColumnIndex, ascendingOrder } = this.state
     const { entriesPerPage, currentPage } = this.state
-    const { host, experiments, tableHeader, enableDownload, downloadTooltip } = this.props
+    const { host, experiments, tableHeader, enableDownload, downloadTooltip, downloadFileTypes } = this.props
 
     const displayedFields = tableHeader.map(header => header.dataParam)
 
@@ -206,7 +206,8 @@ class ExperimentTable extends React.Component {
             host,
             enableDownload,
             currentPageData,
-            downloadTooltip
+            downloadTooltip,
+            downloadFileTypes
           }}
           tableHeaderOnChange={this.tableHeaderOnChange}
           tableHeaderOnClick={this.tableHeaderOnClick}
@@ -247,7 +248,13 @@ ExperimentTable.propTypes = {
       label: PropTypes.string.isRequired,
       dataParam: PropTypes.string.isRequired
     })
-  ).isRequired
+  ).isRequired,
+  downloadFileTypes: PropTypes.arrayOf(
+    PropTypes.shape({
+      description: PropTypes.string,
+      id: PropTypes.string
+    })
+  )
 }
 
 ExperimentTable.defaultProps = {

--- a/src/Prompt.js
+++ b/src/Prompt.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+class Prompt extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      selectedFileTypes: props.downloadFileTypes.map(fileType => fileType.id)
+    }
+
+    this.onClick = this.onClick.bind(this)
+  }
+
+  onClick(selectedFileType) {
+    const selectedFileTypes = [...this.state.selectedFileTypes]
+    this.setState({
+      selectedFileTypes: selectedFileTypes.includes(selectedFileType) ?
+        selectedFileTypes.filter(fileType => fileType !== selectedFileType) :
+        [selectedFileType, ...selectedFileTypes]
+      },
+      () => this.props.onSelect(this.state.selectedFileTypes)
+    )
+  }
+
+  render() {
+    return(
+      <div>
+        <p style={{paddingBottom: `1rem`}}>Choose file types...</p>
+          {
+            this.props.downloadFileTypes.map((fileType) =>
+              <div style={{display:"flex"}}>
+                <input type={`checkbox`} className={`checkbox`} id={fileType.id}
+                       checked={this.state.selectedFileTypes.includes(fileType.id)}
+                       onChange={() => this.onClick(fileType.id)}/>
+                <p style={{paddingLeft: `1rem`, paddingBottom: `1rem`}}>{fileType.description}</p>
+              </div>
+            )
+          }
+
+      </div>
+    )
+  }
+}
+
+Prompt.propTypes = {
+  onSelect: PropTypes.func.isRequired,
+  downloadFileTypes: PropTypes.arrayOf(
+    PropTypes.shape({
+      description: PropTypes.string,
+      id: PropTypes.string
+    })
+  ).isRequired
+}
+
+export default Prompt

--- a/src/Prompt.js
+++ b/src/Prompt.js
@@ -28,12 +28,14 @@ class Prompt extends React.Component {
       <div>
         <p style={{paddingBottom: `1rem`}}>Choose file types...</p>
           {
-            this.props.downloadFileTypes.map((fileType) =>
-              <div style={{display:"flex"}}>
+            this.props.downloadFileTypes.map((fileType, idx) =>
+              <div id={`filetype${idx}`} style={{display:"flex"}}>
                 <input type={`checkbox`} className={`checkbox`} id={fileType.id}
                        checked={this.state.selectedFileTypes.includes(fileType.id)}
                        onChange={() => this.onClick(fileType.id)}/>
-                <p style={{paddingLeft: `1rem`, paddingBottom: `1rem`}}>{fileType.description}</p>
+                <p id={fileType.description} style={{paddingLeft: `1rem`, paddingBottom: `1rem`}}>
+                  {fileType.description}
+                </p>
               </div>
             )
           }

--- a/src/TableContent.js
+++ b/src/TableContent.js
@@ -17,7 +17,6 @@ const fetchJson = async (endpoint, host, queryParams) => {
 }
 
 const alertInvalidFiles = async (host, checkedRows, fileTypes) => {
-  console.log(`alert`, fileTypes)
   const endpoint = `json/experiments/download/zip/check`
 
   try {
@@ -42,7 +41,6 @@ const alertInvalidFiles = async (host, checkedRows, fileTypes) => {
 class TableContent extends React.Component {
   constructor(props) {
     super(props)
-    console.log(props)
 
     this.state = {
       fileTypes: props.enableDownload && props.downloadFileTypes.map(fileType => fileType.id)


### PR DESCRIPTION
I use the react-popup package (as I implemented in smiley feedback window) to create a dialogue window that allows users to select file types out of three options defined in props. The default options are all three. Once users tick any of the checkboxes, the download link will trigger this dialogue window. Users can click the Download button to check the availability of those files with specified file types (companied by [the backend file type PR](https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/69) )and then download window. 